### PR TITLE
move FAQ to separate page

### DIFF
--- a/feedbacksite/surveys/templates/surveys/faq.html
+++ b/feedbacksite/surveys/templates/surveys/faq.html
@@ -1,0 +1,23 @@
+{% extends 'base.html' %}
+
+{% block content %}
+  <h3>FAQ</h3>
+  <p>
+  <b>Why should our feedback be anonymous, anyway?</b></br>
+  It often shouldn't be. We are agnostic, and see merits both ways. The purpose of this site is simply to enable true anonymity, when that is desired.
+  </p>
+  <p>
+  <b>Why do I need to install special software?</b><br>
+  In order to jumble up feedback responses and make them anonymous, we need to store them on a server. We don't want <i>anyone</i>, including site admins, to be able to read this feedback, so we store it encrypted. In order to read it, you decrypt it locally on your computer using your secret private key. This ensures you are the only person who can read your personal feedback.
+  </p>
+  <p>
+  <b>How is my data kept safe?</b></br>
+  Feedback text that you author is sent to the server via a Secure
+  <a href="https://en.wikipedia.org/wiki/HTTPS"> HTTPS Socket</a>,
+  where it is immediately encrypted using
+  <a href="https://en.wikipedia.org/wiki/Public-key_cryptography">
+  Public-key_cryptography</a>.
+  It is stored in this encrypted form until results are published.
+  The only person who can decrypt it is the recipient, using their private key.
+  </p>
+{% endblock %}

--- a/feedbacksite/surveys/templates/surveys/faq.html
+++ b/feedbacksite/surveys/templates/surveys/faq.html
@@ -3,18 +3,18 @@
 {% block content %}
   <h3>FAQ</h3>
   <p>
-  <b>Why should our feedback be anonymous, anyway?</b></br>
-  It often shouldn't be. We are agnostic, and see merits both ways. The purpose of this site is simply to enable true anonymity, when that is desired.
+  <b>Why should feedback be anonymous, anyway?</b></br>
+That's a great question. The purpose of this site is simply to enable true anonymity, when it is desired by a team.
   </p>
   <p>
   <b>Why do I need to install special software?</b><br>
-  In order to jumble up feedback responses and make them anonymous, we need to store them on a server. We don't want <i>anyone</i>, including site admins, to be able to read this feedback, so we store it encrypted. In order to read it, you decrypt it locally on your computer using your secret private key. This ensures you are the only person who can read your personal feedback.
+To jumble up the order of feedback responses and keep them anonymous, we need to store them on a server. We don't want <i>anyone</i>, including site admins, to be able to read this feedback, so we store it encrypted. To read it, you decrypt it locally on your computer using your secret private key. This ensures you are the only person who can read your personal feedback.
   </p>
   <p>
   <b>How is my data kept safe?</b></br>
   Feedback text that you author is sent to the server via a Secure
   <a href="https://en.wikipedia.org/wiki/HTTPS"> HTTPS Socket</a>,
-  where it is immediately encrypted using
+  where it is encrypted using
   <a href="https://en.wikipedia.org/wiki/Public-key_cryptography">
   Public-key_cryptography</a>.
   It is stored in this encrypted form until results are published.

--- a/feedbacksite/surveys/templates/surveys/signup.html
+++ b/feedbacksite/surveys/templates/surveys/signup.html
@@ -22,7 +22,7 @@
   <h3>How to obtain a GPG public key</h3>
   <p>
   To sign up, you will need to install GPG on your computer.
-  To understand why, please read our FAQ at the bottom of this page.
+  To understand why, please read our <a href="{% url 'surveys:faq' %}">FAQ</a>.
   </p>
   <b>GPG installation instructions (Mac OSX)</b><br>
   These roughly follow <a href="ihttp://notes.jerzygangi.com/the-best-pgp-tutorial-for-mac-os-x-ever/">this detailed tutorial</a>.
@@ -40,23 +40,4 @@
     <img src="{% static "surveys/pasted-key.png" %}" width=300px>
     </li>
   </ol>
-  <h3>FAQ</h3>
-  <p>
-  <b>Why should our feedback be anonymous, anyway?</b></br>
-  It often shouldn't be. We are agnostic, and see merits both ways. The purpose of this site is simply to enable true anonymity, when that is desired.
-  </p>
-  <p>
-  <b>Why do I need to install special software?</b><br>
-  In order to jumble up feedback responses and make them anonymous, we need to store them on a server. We don't want <i>anyone</i>, including site admins, to be able to read this feedback, so we store it encrypted. In order to read it, you decrypt it locally on your computer using your secret private key. This ensures you are the only person who can read your personal feedback.
-  </p>
-  <p>
-  <b>How is my data kept safe?</b></br>
-  Feedback text that you author is sent to the server via a Secure
-  <a href="https://en.wikipedia.org/wiki/HTTPS"> HTTPS Socket</a>,
-  where it is immediately encrypted using
-  <a href="https://en.wikipedia.org/wiki/Public-key_cryptography">
-  Public-key_cryptography</a>.
-  It is stored in this encrypted form until results are published.
-  The only person who can decrypt it is the recipient, using their private key.
-  </p>
 {% endblock %}

--- a/feedbacksite/surveys/urls.py
+++ b/feedbacksite/surveys/urls.py
@@ -9,4 +9,5 @@ urlpatterns = [
     path('<int:pk>/submitted/', views.SubmittedView.as_view(), name='submitted'),
     path('<int:pk>/results/', views.ResultsView.as_view(), name='results'),
     path('signup/', views.signup, name='signup'),
+    path('faq/', views.faq, name='faq'),
 ]

--- a/feedbacksite/surveys/views.py
+++ b/feedbacksite/surveys/views.py
@@ -90,3 +90,6 @@ def signup(request):
     else:
         form = GPGUserCreationForm()
     return render(request, 'surveys/signup.html', {'form': form})
+
+def faq(request):
+    return render(request, 'surveys/faq.html')


### PR DESCRIPTION
Figured this would declutter the signup page and allow us to link to the FAQ from within the site for logged-in users.

Also made a few tweaks to the FAQ text. Ready for review, and any suggestions for further improvements are welcome.